### PR TITLE
Optional Validation and Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ address.errors.to_h # => {}
 
 ### Serialization with ActiveRecord
 
-The value object class can be used as the coder for the `serialize` method:
+For columns of `json` type, the value object class can be used as the coder for the `serialize` method:
 
 ```ruby
 class Customer < ActiveRecord::Base
@@ -67,6 +67,14 @@ customer.home_address = AddressValue.new(street: '123 Big Street', postcode: '12
 customer.save
 customer.reload
 customer.home_address # => #<AddressValue:0x00ba9876543210 @street="123 Big Street", @postcode="12345", @city="Metropolis">
+```
+
+For columns of `string` or `text` type, wrap the value object class in a `JsonCoder`:
+
+```ruby
+class Customer < ActiveRecord::Base
+  serialize :home_address, ValueObjects::ActiveRecord::JsonCoder.new(AddressValue)
+end
 ```
 
 ### Validation with ActiveRecord
@@ -111,6 +119,26 @@ customer.home_address # => #<AddressValue:0x00ba9876503210 @street="321 Main St"
 ```
 
 This is functionally similar to what `accepts_nested_attributes_for` does for associations.
+
+Also, `value_object` will use the `JsonCoder` automatically if it detects that the column type is `string` or `text`.
+
+Additional options may be passed in to customize validation:
+
+```ruby
+class Customer < ActiveRecord::Base
+  include ValueObjects::ActiveRecord
+  value_object :home_address, AddressValue, allow_nil: true
+end
+```
+
+Or, to skip validation entirely:
+
+```ruby
+class Customer < ActiveRecord::Base
+  include ValueObjects::ActiveRecord
+  value_object :home_address, AddressValue, no_validation: true
+end
+```
 
 ### Value object collections
 

--- a/lib/value_objects/active_record.rb
+++ b/lib/value_objects/active_record.rb
@@ -16,7 +16,7 @@ module ValueObjects
           value_class
         end
       serialize(attribute, coder)
-      validates_with(::ValueObjects::ValidValidator, options.merge(attributes: [attribute]))
+      validates_with(::ValueObjects::ValidValidator, options.merge(attributes: [attribute])) unless options[:no_validation]
       setter = :"#{attribute}="
       define_method("#{attribute}_attributes=") do |attributes|
         send(setter, value_class.new(attributes))

--- a/lib/value_objects/active_record.rb
+++ b/lib/value_objects/active_record.rb
@@ -8,12 +8,37 @@ module ValueObjects
     end
 
     def value_object(attribute, value_class)
-      serialize(attribute, value_class)
+      coder =
+        case column_for_attribute(attribute).type
+        when :string, :text
+          JsonCoder.new(value_class)
+        else
+          value_class
+        end
+      serialize(attribute, coder)
       validates_with(::ValueObjects::ValidValidator, attributes: [attribute])
       setter = :"#{attribute}="
       define_method("#{attribute}_attributes=") do |attributes|
         send(setter, value_class.new(attributes))
       end
+    end
+
+    class JsonCoder
+
+      EMPTY_ARRAY = [].freeze
+
+      def initialize(value_class)
+        @value_class = value_class
+      end
+
+      def load(value)
+        @value_class.load(JSON.load(value) || EMPTY_ARRAY) if value
+      end
+
+      def dump(value)
+        value.to_json if value
+      end
+
     end
 
   end

--- a/lib/value_objects/active_record.rb
+++ b/lib/value_objects/active_record.rb
@@ -7,7 +7,7 @@ module ValueObjects
       base.extend self
     end
 
-    def value_object(attribute, value_class)
+    def value_object(attribute, value_class, options = {})
       coder =
         case column_for_attribute(attribute).type
         when :string, :text
@@ -16,7 +16,7 @@ module ValueObjects
           value_class
         end
       serialize(attribute, coder)
-      validates_with(::ValueObjects::ValidValidator, attributes: [attribute])
+      validates_with(::ValueObjects::ValidValidator, options.merge(attributes: [attribute]))
       setter = :"#{attribute}="
       define_method("#{attribute}_attributes=") do |attributes|
         send(setter, value_class.new(attributes))

--- a/lib/value_objects/value.rb
+++ b/lib/value_objects/value.rb
@@ -17,11 +17,11 @@ module ValueObjects
     class << self
 
       def load(value)
-        new(JSON.load(value)) if value
+        new(value) if value
       end
 
       def dump(value)
-        value.to_json if value
+        value.to_hash if value
       end
 
       def i18n_scope
@@ -55,11 +55,11 @@ module ValueObjects
         end
 
         def load(values)
-          values.blank? ? [] : JSON.load(values).map { |value| @value_class.new(value) } if values
+          (values.blank? ? [] : values.map { |value| @value_class.new(value) }) if values
         end
 
         def dump(values)
-          values.to_json if values
+          values.map(&:to_hash) if values
         end
 
       end

--- a/spec/value_objects/active_record_spec.rb
+++ b/spec/value_objects/active_record_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe ValueObjects::ActiveRecord do
 
     create_table :test_records do |t|
       t.string :value, default: ''
+      t.string :value1
       t.string :values, default: ''
+      t.string :values1
     end
 
   end
@@ -25,7 +27,9 @@ RSpec.describe ValueObjects::ActiveRecord do
     include ValueObjects::ActiveRecord
 
     value_object :value, FooBarValue, allow_nil: true
+    value_object :value1, FooBarValue, no_validation: true
     value_object :values, FooBarValue::Collection, allow_nil: true
+    value_object :values1, FooBarValue::Collection, no_validation: true
 
   end
 
@@ -96,7 +100,7 @@ RSpec.describe ValueObjects::ActiveRecord do
 
   describe 'validation' do
 
-    let(:record) { TestRecord.new(value: value, values: values).tap(&:valid?) }
+    let(:record) { TestRecord.new(value: value, value1: value, values: values, values1: values).tap(&:valid?) }
 
     context 'with valid values' do
 

--- a/spec/value_objects/active_record_spec.rb
+++ b/spec/value_objects/active_record_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe ValueObjects::ActiveRecord do
     self.verbose = false
 
     create_table :test_records do |t|
-      t.string :value
-      t.string :values
+      t.string :value, default: ''
+      t.string :values, default: ''
     end
 
   end
@@ -24,29 +24,72 @@ RSpec.describe ValueObjects::ActiveRecord do
 
     include ValueObjects::ActiveRecord
 
-    value_object :value, FooBarValue
-    value_object :values, FooBarValue::Collection
+    value_object :value, FooBarValue, allow_nil: true
+    value_object :values, FooBarValue::Collection, allow_nil: true
 
   end
 
   describe 'serialization' do
 
-    let(:value) { FooBarValue.new(foo: '123', bar: 'abc') }
-    let(:values) { [FooBarValue.new(foo: 'abc', bar: '123'), FooBarValue.new(foo: 'cba', bar: 321)] }
-    let(:record) { TestRecord.create!(value: value, values: values).reload }
+    context 'with non-nil values' do
 
-    it 'serializes the value object' do
-      aggregate_failures do
-        expect(record.read_attribute_before_type_cast(:value)).to eq('{"foo":"123","bar":"abc"}')
-        expect(record.read_attribute_before_type_cast(:values)).to eq('[{"foo":"abc","bar":"123"},{"foo":"cba","bar":321}]')
+      let(:value) { FooBarValue.new(foo: '123', bar: 'abc') }
+      let(:values) { [FooBarValue.new(foo: 'abc', bar: '123'), FooBarValue.new(foo: 'cba', bar: 321)] }
+      let(:record) { TestRecord.create!(value: value, values: values).reload }
+
+      it 'serializes the value object' do
+        aggregate_failures do
+          expect(record.read_attribute_before_type_cast(:value)).to eq('{"foo":"123","bar":"abc"}')
+          expect(record.read_attribute_before_type_cast(:values)).to eq('[{"foo":"abc","bar":"123"},{"foo":"cba","bar":321}]')
+        end
       end
+
+      it 'deserializes the value object' do
+        aggregate_failures do
+          expect(record.read_attribute(:value)).to eq(value)
+          expect(record.read_attribute(:values)).to eq(values)
+        end
+      end
+
     end
 
-    it 'deserializes the value object' do
-      aggregate_failures do
-        expect(record.read_attribute(:value)).to eq(value)
-        expect(record.read_attribute(:values)).to eq(values)
+    context 'with nil values' do
+
+      let(:value) { nil }
+      let(:values) { nil }
+      let(:record) { TestRecord.create!(value: value, values: values).reload }
+
+      it 'serializes the value object' do
+        aggregate_failures do
+          expect(record.read_attribute_before_type_cast(:value)).to eq(nil)
+          expect(record.read_attribute_before_type_cast(:values)).to eq(nil)
+        end
       end
+
+      it 'deserializes the value object' do
+        aggregate_failures do
+          expect(record.read_attribute(:value)).to eq(value)
+          expect(record.read_attribute(:values)).to eq(values)
+        end
+      end
+
+    end
+
+    context 'with blank values' do
+
+      let(:value) { FooBarValue.new }
+      let(:values) { [] }
+      let(:record) { TestRecord.new.tap { |r| r.save!(validate: false) }.reload }
+
+      it 'deserializes the value object' do
+        aggregate_failures do
+          expect(record.read_attribute_before_type_cast(:value)).to eq('')
+          expect(record.read_attribute_before_type_cast(:values)).to eq('')
+          expect(record.read_attribute(:value)).to eq(value)
+          expect(record.read_attribute(:values)).to eq(values)
+        end
+      end
+
     end
 
   end

--- a/spec/value_objects/value_spec.rb
+++ b/spec/value_objects/value_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ValueObjects::Value do
 
     context 'with empty value' do
 
-      let(:value) { TestValue.load('') }
+      let(:value) { TestValue.load({}) }
 
       it { expect(value).to eq(TestValue.new) }
 
@@ -64,7 +64,7 @@ RSpec.describe ValueObjects::Value do
 
     context 'with non-empty value' do
 
-      let(:value) { TestValue.load('{"foo":321,"bar":"cba"}') }
+      let(:value) { TestValue.load('foo' => 321, 'bar' => 'cba') }
 
       it { expect(value).to eq(TestValue.new(foo: 321, bar: 'cba')) }
 
@@ -86,7 +86,7 @@ RSpec.describe ValueObjects::Value do
 
       let(:value) { TestValue.dump(TestValue.new) }
 
-      it { expect(value).to eq('{"foo":null,"bar":null}') }
+      it { expect(value).to eq(foo: nil, bar: nil) }
 
     end
 
@@ -94,7 +94,7 @@ RSpec.describe ValueObjects::Value do
 
       let(:value) { TestValue.dump(TestValue.new(foo: 321, bar: 'cba')) }
 
-      it { expect(value).to eq('{"foo":321,"bar":"cba"}') }
+      it { expect(value).to eq(foo: 321, bar: 'cba') }
 
     end
 
@@ -146,7 +146,7 @@ RSpec.describe ValueObjects::Value do
 
     context 'with empty value' do
 
-      let(:value) { TestValue::Collection.load('') }
+      let(:value) { TestValue::Collection.load([]) }
 
       it { expect(value).to eq([]) }
 
@@ -154,7 +154,7 @@ RSpec.describe ValueObjects::Value do
 
     context 'with non-empty value' do
 
-      let(:value) { TestValue::Collection.load('[{"foo":321,"bar":"cba"},{"foo":"abc","bar":123}]') }
+      let(:value) { TestValue::Collection.load([{ 'foo' => 321, 'bar' => 'cba' }, { 'foo' => 'abc', 'bar' => 123 }]) }
 
       it { expect(value).to eq([TestValue.new(foo: 321, bar: 'cba'), TestValue.new(foo: 'abc', bar: 123)]) }
 
@@ -176,7 +176,7 @@ RSpec.describe ValueObjects::Value do
 
       let(:values) { TestValue::Collection.dump([]) }
 
-      it { expect(values).to eq('[]') }
+      it { expect(values).to eq([]) }
 
     end
 
@@ -184,7 +184,7 @@ RSpec.describe ValueObjects::Value do
 
       let(:values) { TestValue::Collection.dump([TestValue.new(foo: 123, bar: 'abc'), TestValue.new(foo: 'cba', bar: 321)]) }
 
-      it { expect(values).to eq('[{"foo":123,"bar":"abc"},{"foo":"cba","bar":321}]') }
+      it { expect(values).to eq([{ foo: 123, bar: 'abc' }, { foo: 'cba', bar: 321 }]) }
 
     end
 


### PR DESCRIPTION
- Changes `ValueObjects::Value` to work natively on `json` column types.
- Added `ValueObjects::ActiveRecord::JsonCoder` to support `string` and `text` column types.
- Enhance `value_object` in `ValueObjects::ActiveRecord` to make validation optional and support validation options.